### PR TITLE
Re-design GUI layout to multiple display panels

### DIFF
--- a/src/main/java/seedu/address/ui/IngredientResultDisplay.java
+++ b/src/main/java/seedu/address/ui/IngredientResultDisplay.java
@@ -1,0 +1,27 @@
+package seedu.address.ui;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.TextArea;
+import javafx.scene.layout.Region;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A ui for the status bar that is displayed at the header of the application.
+ */
+public class IngredientResultDisplay extends UiPart<Region> {
+
+    private static final String FXML = "ResultDisplay.fxml";
+
+    @FXML
+    private TextArea resultDisplay;
+
+    public IngredientResultDisplay() {
+        super(FXML);
+    }
+
+    public void setFeedbackToUser(String feedbackToUser) {
+        requireNonNull(feedbackToUser);
+        resultDisplay.setText(feedbackToUser);
+    }
+}

--- a/src/main/java/seedu/address/ui/IngredientResultDisplay.java
+++ b/src/main/java/seedu/address/ui/IngredientResultDisplay.java
@@ -1,10 +1,11 @@
 package seedu.address.ui;
 
+import static java.util.Objects.requireNonNull;
+
 import javafx.fxml.FXML;
 import javafx.scene.control.TextArea;
 import javafx.scene.layout.Region;
 
-import static java.util.Objects.requireNonNull;
 
 /**
  * A ui for the status bar that is displayed at the header of the application.

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -33,6 +33,8 @@ public class MainWindow extends UiPart<Stage> {
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
     private ResultDisplay resultDisplay;
+    private SalesResultDisplay salesResultDisplay;
+    private IngredientResultDisplay ingredientResultDisplay;
     private HelpWindow helpWindow;
 
     @FXML
@@ -46,6 +48,12 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private StackPane resultDisplayPlaceholder;
+
+    @FXML
+    private StackPane salesResultDisplayPlaceholder;
+
+    @FXML
+    private StackPane ingredientResultDisplayPlaceholder;
 
     @FXML
     private StackPane statusbarPlaceholder;
@@ -110,6 +118,12 @@ public class MainWindow extends UiPart<Stage> {
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
+        salesResultDisplay = new SalesResultDisplay();
+        salesResultDisplayPlaceholder.getChildren().add(salesResultDisplay.getRoot());
+
+        ingredientResultDisplay = new IngredientResultDisplay();
+        ingredientResultDisplayPlaceholder.getChildren().add(ingredientResultDisplay.getRoot());
+
         StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
@@ -170,7 +184,14 @@ public class MainWindow extends UiPart<Stage> {
         try {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
-            resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
+
+            if (commandText.startsWith("s-list")) {
+                salesResultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
+            } else if (commandText.startsWith("i-list")) {
+                ingredientResultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
+            } else {
+                resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
+            }
 
             if (commandResult.isShowHelp()) {
                 handleHelp();

--- a/src/main/java/seedu/address/ui/SalesResultDisplay.java
+++ b/src/main/java/seedu/address/ui/SalesResultDisplay.java
@@ -1,0 +1,27 @@
+package seedu.address.ui;
+
+import static java.util.Objects.requireNonNull;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.TextArea;
+import javafx.scene.layout.Region;
+
+/**
+ * A ui for the status bar that is displayed at the header of the application.
+ */
+public class SalesResultDisplay extends UiPart<Region> {
+
+    private static final String FXML = "ResultDisplay.fxml";
+
+    @FXML
+    private TextArea resultDisplay;
+
+    public SalesResultDisplay() {
+        super(FXML);
+    }
+
+    public void setFeedbackToUser(String feedbackToUser) {
+        requireNonNull(feedbackToUser);
+        resultDisplay.setText(feedbackToUser);
+    }
+}

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -150,10 +150,17 @@
      -fx-background-color: derive(#1d1d1d, 20%);
 }
 
-.pane-with-border {
+.pane-with-border{
      -fx-background-color: derive(#1d1d1d, 20%);
      -fx-border-color: derive(#1d1d1d, 10%);
      -fx-border-top-width: 1px;
+}
+
+.pane-with-border-orange{
+    -fx-background-color: derive(#1d1d1d, 20%);
+    -fx-border-color: derive(#1d1d1d, 10%);
+    -fx-border-top-width: 9px;
+    -fx-border-color: derive(#d2691e, 20%);
 }
 
 .status-bar {

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -146,6 +146,13 @@
     -fx-text-fill: #010504;
 }
 
+.cell_small_label_italic {
+    -fx-font-family: "Segoe UI Semibold";
+    -fx-font-size: 13px;
+    -fx-text-fill: #010504;
+    -fx-font-style: italic;
+}
+
 .stack-pane {
      -fx-background-color: derive(#1d1d1d, 20%);
 }

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -6,13 +6,15 @@
 <?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
-<?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.image.Image?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.stage.Stage?>
 
-<fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
-         title="Address App" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
+<fx:root minHeight="700" minWidth="1000" onCloseRequest="#handleExit" title="tCheck" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>
@@ -33,25 +35,69 @@
           </Menu>
         </MenuBar>
 
-        <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
+        <StackPane fx:id="commandBoxPlaceholder" styleClass="pane-with-border" VBox.vgrow="NEVER">
           <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
+            <Insets bottom="5" left="10" right="10" top="5" />
           </padding>
         </StackPane>
 
-        <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-                   minHeight="100" prefHeight="100" maxHeight="100">
+        <StackPane fx:id="resultDisplayPlaceholder" maxHeight="300" minHeight="100" prefHeight="300.0" styleClass="pane-with-border">
           <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
+            <Insets bottom="5" left="10" right="10" top="5" />
           </padding>
         </StackPane>
 
-        <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
-          <padding>
-            <Insets top="10" right="10" bottom="10" left="10" />
-          </padding>
-          <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-        </VBox>
+            <GridPane>
+              <columnConstraints>
+                <ColumnConstraints hgrow="ALWAYS" minWidth="100.0" prefWidth="100.0" />
+                  <ColumnConstraints hgrow="ALWAYS" minWidth="100.0" prefWidth="100.0" />
+              </columnConstraints>
+              <rowConstraints>
+                  <RowConstraints maxHeight="400.0" minHeight="200.0" prefHeight="300.0" vgrow="ALWAYS" />
+                  <RowConstraints maxHeight="400.0" minHeight="200.0" prefHeight="300.0" vgrow="ALWAYS" />
+              </rowConstraints>
+               <children>
+
+                 <VBox fx:id="salesList" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="80.0" prefWidth="150.0" styleClass="pane-with-border-orange">
+                     <padding>
+                        <Insets bottom="10" left="10" right="10" top="10" />
+                     </padding>
+                     <children>
+                        <StackPane fx:id="salesResultDisplayPlaceholder" prefHeight="78.0" prefWidth="150.0"
+                                   VBox.vgrow="ALWAYS" />
+                     </children>
+                  </VBox>
+
+                  <VBox fx:id="ingredientList" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308"
+                        prefHeight="80.0" prefWidth="150.0" styleClass="pane-with-border-orange" GridPane.columnIndex="1">
+                     <padding>
+                        <Insets bottom="10" left="10" right="10" top="10" />
+                     </padding>
+                     <children>
+                         <StackPane fx:id="ingredientResultDisplayPlaceholder" prefHeight="78.0" prefWidth="150.0"
+                                    VBox.vgrow="ALWAYS" />
+                     </children>
+                  </VBox>
+
+                   <VBox fx:id="personList" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="80.0" prefWidth="150.0" styleClass="pane-with-border-orange" GridPane.columnIndex="0" GridPane.rowIndex="1">
+                       <padding>
+                           <Insets bottom="10" left="10" right="10" top="10" />
+                       </padding>
+
+                       <StackPane fx:id="personListPanelPlaceholder" prefHeight="78.0" prefWidth="150.0" VBox.vgrow="ALWAYS" />
+                   </VBox>
+
+                  <VBox fx:id="personList3" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="80.0" prefWidth="150.0" styleClass="pane-with-border-orange" GridPane.columnIndex="1" GridPane.rowIndex="1">
+                     <padding>
+                        <Insets bottom="10" left="10" right="10" top="10" />
+                     </padding>
+                     <children>
+                        <StackPane fx:id="personListPanelPlaceholder3" prefHeight="78.0" prefWidth="150.0" VBox.vgrow="ALWAYS" />
+                     </children>
+                  </VBox>
+
+               </children>
+            </GridPane>
 
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
       </VBox>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -7,30 +7,61 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="10" />
     </columnConstraints>
     <VBox alignment="CENTER_LEFT" minHeight="20" GridPane.columnIndex="0">
       <padding>
-        <Insets top="5" right="5" bottom="5" left="15" />
+        <Insets bottom="5" left="15" right="5" top="5" />
       </padding>
-      <HBox spacing="5" alignment="CENTER_LEFT">
+      <HBox alignment="CENTER_LEFT" spacing="5">
         <Label fx:id="id" styleClass="cell_big_label">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
       </HBox>
       <FlowPane fx:id="tags" />
-      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-      <Label fx:id="emergency" styleClass="cell_small_label" text="\$emergency" />
-      <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
+         <HBox alignment="CENTER_LEFT" spacing="5">
+            <children>
+               <Label fx:id="id1" styleClass="cell_big_label" text="Contact Number: ">
+                  <minWidth>
+                     <Region fx:constant="USE_PREF_SIZE" />
+                  </minWidth>
+               </Label>
+            <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
+            </children>
+         </HBox>
+         <HBox alignment="CENTER_LEFT" spacing="5">
+            <children>
+               <Label fx:id="id11" styleClass="cell_big_label" text="Emergency Contact:  ">
+                  <minWidth>
+                     <Region fx:constant="USE_PREF_SIZE" />
+                  </minWidth>
+               </Label>
+            <Label fx:id="emergency" styleClass="cell_small_label" text="\$emergency" />
+            </children>
+         </HBox>
+         <HBox alignment="CENTER_LEFT" spacing="5">
+            <children>
+               <Label fx:id="id111" styleClass="cell_big_label" text="Address: ">
+                  <minWidth>
+                     <Region fx:constant="USE_PREF_SIZE" />
+                  </minWidth>
+               </Label>
+            <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
+            </children>
+         </HBox>
     </VBox>
+      <rowConstraints>
+         <RowConstraints />
+      </rowConstraints>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -31,7 +31,7 @@
       <FlowPane fx:id="tags" />
          <HBox alignment="CENTER_LEFT" spacing="5">
             <children>
-               <Label fx:id="id1" styleClass="cell_big_label" text="Contact Number: ">
+               <Label fx:id="id1" styleClass="cell_small_label_italic" text="Contact Number: " >
                   <minWidth>
                      <Region fx:constant="USE_PREF_SIZE" />
                   </minWidth>
@@ -41,7 +41,7 @@
          </HBox>
          <HBox alignment="CENTER_LEFT" spacing="5">
             <children>
-               <Label fx:id="id11" styleClass="cell_big_label" text="Emergency Contact:  ">
+               <Label fx:id="id11" styleClass="cell_small_label_italic" text="Emergency Contact: ">
                   <minWidth>
                      <Region fx:constant="USE_PREF_SIZE" />
                   </minWidth>
@@ -51,7 +51,7 @@
          </HBox>
          <HBox alignment="CENTER_LEFT" spacing="5">
             <children>
-               <Label fx:id="id111" styleClass="cell_big_label" text="Address: ">
+               <Label fx:id="id111" styleClass="cell_small_label_italic" text="Address: ">
                   <minWidth>
                      <Region fx:constant="USE_PREF_SIZE" />
                   </minWidth>


### PR DESCRIPTION
- Split the display panel to Ingredient-related, sales-related and contact-related display panels.
- Add some design components in DarkTheme.css
- Improve the current contact GUI by adding a title in front of each data. (eg. instead of displaying "81234567", now displaying "Contact Number: 81234567")