### PR TITLE
Fix find-related bugs

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -280,7 +280,7 @@ Format: `c-list`
 
 #### 3.3 Listing all employees who are working today: `c-today`
 
-Shows a list of all employees whose tags contain today's day (i.e. `Wednesday`, `Tuesday`, etc).
+Shows a list of all active(unarchived) employees whose tags contain today's day (i.e. `Wednesday`, `Tuesday`, etc).
 
 Format: `c-today`
 
@@ -292,7 +292,7 @@ Examples:
 
 #### 3.4 Listing all employees who are working tomorrow: `c-tomorrow`
 
-Shows a list of all employees whose tags contain tomorrow's day (i.e. `Wednesday`, `Tuesday`, etc).
+Shows a list of all active(unarchived) employees whose tags contain tomorrow's day (i.e. `Wednesday`, `Tuesday`, etc).
 
 Format: `c-tomorrow`
 
@@ -324,7 +324,7 @@ Examples:
 
 #### 3.6 Locating persons by keywords: `c-find`
 
-Finds all contacts that contain the KEYWORD(s) in their names.
+Finds all active(unarchived) contacts that contain the KEYWORD(s) in their names.
 
 Format: `c-find KEYWORD [MORE_KEYWORDS]`
 
@@ -341,7 +341,7 @@ Examples:
 
 #### 3.7 Locating persons based on matching tags: `c-tag-find`
 
-Finds all contacts that contain the KEYWORD(s) in their tags.
+Finds all active(unarchived) contacts that contain the KEYWORD(s) in their tags.
 
 Format: `c-tag-find KEYWORD [MORE_KEYWORDS]`
 

--- a/src/main/java/seedu/address/logic/commands/FindByTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindByTagCommand.java
@@ -7,15 +7,15 @@ import seedu.address.model.Model;
 import seedu.address.model.person.TagContainsKeywordsPredicate;
 
 /**
- * Finds and lists all persons in address book whose tag(s) contains any of the argument keywords.
+ * Finds and lists all active(unarchived) persons in address book whose tag(s) contains any of the argument keywords.
  * Keyword matching is case insensitive.
  */
 public class FindByTagCommand extends Command {
 
     public static final String COMMAND_WORD = "c-tag-find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose tag(s) contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose tag(s) contain "
+            +"any of the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " friday monday PartTime";
 

--- a/src/main/java/seedu/address/logic/commands/FindByTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindByTagCommand.java
@@ -15,7 +15,7 @@ public class FindByTagCommand extends Command {
     public static final String COMMAND_WORD = "c-tag-find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose tag(s) contain "
-            +"any of the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "any of the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " friday monday PartTime";
 

--- a/src/main/java/seedu/address/logic/commands/FindByTagTodayCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindByTagTodayCommand.java
@@ -8,10 +8,11 @@ import java.time.LocalDate;
 import seedu.address.model.Model;
 
 /**
- * Finds and lists all persons in address book whose tag(s) contains today's day (i.e. Monday, Tuesday, etc).
+ * Finds and lists all active(unarchived) persons in address book whose tag(s) contains today's day (i.e. Monday,
+ * Tuesday, etc).
  *
- * For example, assume today is Tuesday, after command "c-today", all employees whose tag(s) contains
- * "tuesday", case-insensitive, will be listed out.
+ * For example, assume today is Tuesday, after command "c-today", all active(unarchived) employees whose tag(s)
+ * contains "tuesday", case-insensitive, will be listed out.
  */
 public class FindByTagTodayCommand extends Command {
     public static final String COMMAND_WORD = "c-today";

--- a/src/main/java/seedu/address/logic/commands/FindByTagTodayCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindByTagTodayCommand.java
@@ -30,25 +30,25 @@ public class FindByTagTodayCommand extends Command {
 
         switch (dayOfWeek) {
         case SUNDAY:
-            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_SUNDAY_PERSONS);
+            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_ACTIVE_SUNDAY_PERSONS);
             break;
         case MONDAY:
-            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_MONDAY_PERSONS);
+            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_ACTIVE_MONDAY_PERSONS);
             break;
         case TUESDAY:
-            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_TUESDAY_PERSONS);
+            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_ACTIVE_TUESDAY_PERSONS);
             break;
         case WEDNESDAY:
-            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_WEDNESDAY_PERSONS);
+            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_ACTIVE_WEDNESDAY_PERSONS);
             break;
         case THURSDAY:
-            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_THURSDAY_PERSONS);
+            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_ACTIVE_THURSDAY_PERSONS);
             break;
         case FRIDAY:
-            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_FRIDAY_PERSONS);
+            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_ACTIVE_FRIDAY_PERSONS);
             break;
         case SATURDAY:
-            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_SATURDAY_PERSONS);
+            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_ACTIVE_SATURDAY_PERSONS);
             break;
         default:
             model.updateFilteredPersonList(person -> false);

--- a/src/main/java/seedu/address/logic/commands/FindByTagTomorrowCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindByTagTomorrowCommand.java
@@ -30,25 +30,25 @@ public class FindByTagTomorrowCommand extends Command {
 
         switch (dayOfWeek) {
         case SUNDAY:
-            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_SUNDAY_PERSONS);
+            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_ACTIVE_SUNDAY_PERSONS);
             break;
         case MONDAY:
-            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_MONDAY_PERSONS);
+            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_ACTIVE_MONDAY_PERSONS);
             break;
         case TUESDAY:
-            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_TUESDAY_PERSONS);
+            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_ACTIVE_TUESDAY_PERSONS);
             break;
         case WEDNESDAY:
-            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_WEDNESDAY_PERSONS);
+            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_ACTIVE_WEDNESDAY_PERSONS);
             break;
         case THURSDAY:
-            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_THURSDAY_PERSONS);
+            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_ACTIVE_THURSDAY_PERSONS);
             break;
         case FRIDAY:
-            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_FRIDAY_PERSONS);
+            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_ACTIVE_FRIDAY_PERSONS);
             break;
         case SATURDAY:
-            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_SATURDAY_PERSONS);
+            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_ACTIVE_SATURDAY_PERSONS);
             break;
         default:
             model.updateFilteredPersonList(person -> false);

--- a/src/main/java/seedu/address/logic/commands/FindByTagTomorrowCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindByTagTomorrowCommand.java
@@ -8,10 +8,11 @@ import java.time.LocalDate;
 import seedu.address.model.Model;
 
 /**
- * Finds and lists all persons in address book whose tag(s) contains the next-day's day (i.e. Monday, Tuesday, etc).
+ * Finds and lists all active(unarchived) persons in address book whose tag(s) contains the next-day's day (i.e.
+ * Monday, Tuesday, etc).
  *
- * For example, assume today is Tuesday, after command "c-tomorrow", all employees whose tag(s) contains
- * "wednesday", case-insensitive, will be listed out.
+ * For example, assume today is Tuesday, after command "c-tomorrow", all active(unarchived) employees whose tag(s)
+ * contains "wednesday", case-insensitive, will be listed out.
  */
 public class FindByTagTomorrowCommand extends Command {
     public static final String COMMAND_WORD = "c-tomorrow";

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -7,7 +7,7 @@ import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
+ * Finds and lists all active(unarchived) persons in address book whose name contains any of the argument keywords.
  * Keyword matching is case insensitive.
  */
 public class FindCommand extends Command {

--- a/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
@@ -56,7 +56,7 @@ public class UnarchiveCommand extends Command {
 
         Person unarchivedPerson = personToUnarchive.unarchive();
         model.setPerson(personToUnarchive, unarchivedPerson);
-        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_ACTIVE_PERSONS);
+        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_ARCHIVED_PERSONS);
         return new CommandResult(String.format(MESSAGE_UNARCHIVE_PERSON_SUCCESS, personToUnarchive.getName()));
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -24,20 +24,27 @@ public interface Model {
     Predicate<Person> PREDICATE_SHOW_ALL_ARCHIVED_PERSONS = person -> (
             person.getArchiveStatus().archiveStatus);
 
-    Predicate<Person> PREDICATE_SHOW_ALL_MONDAY_PERSONS = person -> (
-            person.getTags().toString().toLowerCase().contains("monday"));
-    Predicate<Person> PREDICATE_SHOW_ALL_TUESDAY_PERSONS = person -> (
-            person.getTags().toString().toLowerCase().contains("tuesday"));
-    Predicate<Person> PREDICATE_SHOW_ALL_WEDNESDAY_PERSONS = person -> (
-            person.getTags().toString().toLowerCase().contains("wednesday"));
-    Predicate<Person> PREDICATE_SHOW_ALL_THURSDAY_PERSONS = person -> (
-            person.getTags().toString().toLowerCase().contains("thursday"));
-    Predicate<Person> PREDICATE_SHOW_ALL_FRIDAY_PERSONS = person -> (
-            person.getTags().toString().toLowerCase().contains("friday"));
-    Predicate<Person> PREDICATE_SHOW_ALL_SATURDAY_PERSONS = person -> (
-            person.getTags().toString().toLowerCase().contains("saturday"));
-    Predicate<Person> PREDICATE_SHOW_ALL_SUNDAY_PERSONS = person -> (
-            person.getTags().toString().toLowerCase().contains("sunday"));
+    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_MONDAY_PERSONS = person ->(
+            (!person.getArchiveStatus().archiveStatus)
+                    && person.getTags().toString().toLowerCase().contains("monday"));
+    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_TUESDAY_PERSONS = person -> (
+            (!person.getArchiveStatus().archiveStatus)
+                    && person.getTags().toString().toLowerCase().contains("tuesday"));
+    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_WEDNESDAY_PERSONS = person -> (
+            (!person.getArchiveStatus().archiveStatus)
+                    && person.getTags().toString().toLowerCase().contains("wednesday"));
+    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_THURSDAY_PERSONS = person -> (
+            (!person.getArchiveStatus().archiveStatus)
+                    && person.getTags().toString().toLowerCase().contains("thursday"));
+    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_FRIDAY_PERSONS = person -> (
+            (!person.getArchiveStatus().archiveStatus)
+                    && person.getTags().toString().toLowerCase().contains("friday"));
+    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_SATURDAY_PERSONS = person -> (
+            (!person.getArchiveStatus().archiveStatus)
+                    && person.getTags().toString().toLowerCase().contains("saturday"));
+    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_SUNDAY_PERSONS = person -> (
+            (!person.getArchiveStatus().archiveStatus)
+                    && person.getTags().toString().toLowerCase().contains("sunday"));
 
     Predicate<Ingredient> PREDICATE_SHOW_ALL_INGREDIENTS = unused -> true;
     Predicate<SalesRecordEntry> PREDICATE_SHOW_ALL_SALES_RECORD_ENTRY = unused -> true;

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -24,26 +24,26 @@ public interface Model {
     Predicate<Person> PREDICATE_SHOW_ALL_ARCHIVED_PERSONS = person -> (
             person.getArchiveStatus().archiveStatus);
 
-    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_MONDAY_PERSONS = person ->(
-            (!person.getArchiveStatus().archiveStatus)
+    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_MONDAY_PERSONS = person ->((
+            !person.getArchiveStatus().archiveStatus)
                     && person.getTags().toString().toLowerCase().contains("monday"));
-    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_TUESDAY_PERSONS = person -> (
-            (!person.getArchiveStatus().archiveStatus)
+    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_TUESDAY_PERSONS = person -> ((
+            !person.getArchiveStatus().archiveStatus)
                     && person.getTags().toString().toLowerCase().contains("tuesday"));
-    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_WEDNESDAY_PERSONS = person -> (
-            (!person.getArchiveStatus().archiveStatus)
+    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_WEDNESDAY_PERSONS = person -> ((
+            !person.getArchiveStatus().archiveStatus)
                     && person.getTags().toString().toLowerCase().contains("wednesday"));
-    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_THURSDAY_PERSONS = person -> (
-            (!person.getArchiveStatus().archiveStatus)
+    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_THURSDAY_PERSONS = person -> ((
+            !person.getArchiveStatus().archiveStatus)
                     && person.getTags().toString().toLowerCase().contains("thursday"));
-    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_FRIDAY_PERSONS = person -> (
-            (!person.getArchiveStatus().archiveStatus)
+    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_FRIDAY_PERSONS = person -> ((
+            !person.getArchiveStatus().archiveStatus)
                     && person.getTags().toString().toLowerCase().contains("friday"));
-    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_SATURDAY_PERSONS = person -> (
-            (!person.getArchiveStatus().archiveStatus)
+    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_SATURDAY_PERSONS = person -> ((
+            !person.getArchiveStatus().archiveStatus)
                     && person.getTags().toString().toLowerCase().contains("saturday"));
-    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_SUNDAY_PERSONS = person -> (
-            (!person.getArchiveStatus().archiveStatus)
+    Predicate<Person> PREDICATE_SHOW_ALL_ACTIVE_SUNDAY_PERSONS = person -> ((
+            !person.getArchiveStatus().archiveStatus)
                     && person.getTags().toString().toLowerCase().contains("sunday"));
 
     Predicate<Ingredient> PREDICATE_SHOW_ALL_INGREDIENTS = unused -> true;

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -17,7 +17,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
-        return keywords.stream()
+        return (!person.getArchiveStatus().archiveStatus) && keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
     }
 

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -6,7 +6,7 @@ import java.util.function.Predicate;
 import seedu.address.commons.util.StringUtil;
 
 /**
- * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
+ * Tests that a {@code Person}'s {@code Name} matches any of the keywords given and the person is not archived.
  */
 public class NameContainsKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;

--- a/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
@@ -19,7 +19,7 @@ public class TagContainsKeywordsPredicate implements Predicate<Person> {
     public boolean test(Person person) {
         return ((!person.getArchiveStatus().archiveStatus)
                 && keywords.stream().anyMatch(keyword
-                        -> StringUtil
+                    -> StringUtil
                         .containsWordIgnoreCase(person.getTags().toString()
                                 .replaceAll("\\[", "")
                                 .replaceAll("]", "")

--- a/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
@@ -17,13 +17,13 @@ public class TagContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
-        return keywords.stream()
-                .anyMatch(keyword
-                    -> StringUtil
+        return ((!person.getArchiveStatus().archiveStatus)
+                && keywords.stream().anyMatch(keyword
+                        -> StringUtil
                         .containsWordIgnoreCase(person.getTags().toString()
-                                        .replaceAll("\\[", "")
-                                        .replaceAll("]", "")
-                                        .replaceAll(",", ""), keyword));
+                                .replaceAll("\\[", "")
+                                .replaceAll("]", "")
+                                .replaceAll(",", ""), keyword)));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
@@ -6,7 +6,7 @@ import java.util.function.Predicate;
 import seedu.address.commons.util.StringUtil;
 
 /**
- * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
+ * Tests that a {@code Person}'s {@code Tags} matches any of the keywords given and the person is not archived.
  */
 public class TagContainsKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;


### PR DESCRIPTION
Bugs: it returned all matching persons (including archived ones) when `c-find`, `c-tag-find`, `c-today`, `c-tomorrow` commands are given

After fixing: Now, when these 4 commands are given, tCheck will only search through all active(unarchived) persons, ignoring all archived persons.