### PR TITLE
Make feedback messages more informative

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ArchiveAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchiveAllCommand.java
@@ -14,11 +14,13 @@ public class ArchiveAllCommand extends Command {
     public static final String COMMAND_WORD = "c-archive-all";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Archives all persons in the displayed person list.\n";
+            + ": Archives all employees in the displayed employee directory.\n";
 
-    public static final String MESSAGE_ARCHIVE_PERSON_SUCCESS = "Archived all persons in the displayed person list";
+    public static final String MESSAGE_ARCHIVE_PERSON_SUCCESS = "Archived all employees in the displayed employee "
+            + "directory";
 
-    public static final String MESSAGE_NOTHING_TO_ARCHIVE = "There is nothing in the current displayed list";
+    public static final String MESSAGE_NOTHING_TO_ARCHIVE = "There is no employee in the current displayed employee "
+            + "directory";
 
     @Override
     public CommandResult execute(Model model) throws CommandException {

--- a/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
-import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -19,12 +18,18 @@ public class ArchiveCommand extends Command {
     public static final String COMMAND_WORD = "c-archive";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Archives the person identified by the index number used in the displayed person list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
+            + ": Archives the employee identified by the index number used in the displayed employee list.\n"
+            + "Parameter: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_ARCHIVE_PERSON_SUCCESS = "Archived Person: %1$s";
-    public static final String MESSAGE_PERSON_ALREADY_ARCHIVED = "This person has already been archived!";
+    public static final String MESSAGE_ARCHIVE_PERSON_SUCCESS = "Archived Employee: %1$s";
+    public static final String MESSAGE_PERSON_ALREADY_ARCHIVED = "This employee has already been archived!"
+            + "\nOnly employees in active list can be archived."
+            + "\nTo view all active(unarchived) employees, use command 'c-active-list'.";
+
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX_ARCHIVE = "The employee index provided is "
+            + "invalid."
+            + "\nThere are only %1$s employees displayed in the employee directory pane.";
 
     private final Index targetIndex;
 
@@ -45,7 +50,8 @@ public class ArchiveCommand extends Command {
 
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(String.format(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX_ARCHIVE,
+                    model.getFilteredPersonList().size()));
         }
 
         Person personToArchive = lastShownList.get(targetIndex.getZeroBased());

--- a/src/main/java/seedu/address/logic/commands/ArchiveListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchiveListCommand.java
@@ -14,7 +14,7 @@ public class ArchiveListCommand extends Command {
 
     public static final String COMMAND_WORD = "c-archive-list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all archived persons.";
+    public static final String MESSAGE_SUCCESS = "Listed all archived employees.";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/FindByTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindByTagCommand.java
@@ -14,7 +14,7 @@ public class FindByTagCommand extends Command {
 
     public static final String COMMAND_WORD = "c-tag-find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose tag(s) contain "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all employees whose tag(s) contain "
             + "any of the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " friday monday PartTime";

--- a/src/main/java/seedu/address/logic/commands/FindByTagTodayCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindByTagTodayCommand.java
@@ -18,10 +18,10 @@ public class FindByTagTodayCommand extends Command {
     public static final String COMMAND_WORD = "c-today";
 
     public static final String MESSAGE_SUCCESS = "Today is %2$s."
-            + "\nThere are total %1$s employees working today."
-            + "\nThey are listed below.";
+            + "\nThere are total %1$s employees available today."
+            + "\nThey are listed below in the employee directory pane.";
     public static final String MESSAGE_NO_EMPLOYEE = "Today is %1$s."
-            + "\nBased on the contact list, no employee is working today.";
+            + "\nBased on the tCheck's employee directory, no employee is available today.";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/FindByTagTomorrowCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindByTagTomorrowCommand.java
@@ -19,9 +19,9 @@ public class FindByTagTomorrowCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Tomorrow is %2$s."
             + "\nThere are total %1$s employees working tomorrow."
-            + "\nThey are listed below.";
+            + "\nThey are listed below in the employee directory pane.";
     public static final String MESSAGE_NO_EMPLOYEE = "Tomorrow is %1$s."
-            + "\nBased on the contact list, no employee is working tomorrow.";
+            + "\nBased on the tCheck's employee directory, no employee is available tomorrow.";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -10,9 +10,9 @@ import seedu.address.model.Model;
  */
 public class ListCommand extends Command {
 
-    public static final String COMMAND_WORD = "c-list";
+    public static final String COMMAND_WORD = "c-active-list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_SUCCESS = "Listed all employees in the employee directory pane.";
 
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
-import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -20,13 +19,17 @@ public class UnarchiveCommand extends Command {
     public static final String COMMAND_WORD = "c-unarchive";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Unarchives the person identified by the index number used in the displayed person list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
+            + ": Unarchives the employee identified by the index number used in the displayed employee directory.\n"
+            + "Parameter: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_UNARCHIVE_PERSON_SUCCESS = "Unarchived Person: %1$s";
-    public static final String MESSAGE_PERSON_ALREADY_ACTIVE = "This person is already in the active list!";
-
+    public static final String MESSAGE_UNARCHIVE_PERSON_SUCCESS = "Unarchived employee: %1$s";
+    public static final String MESSAGE_PERSON_ALREADY_ACTIVE = "This employee is already in the active list!"
+            + "\nOnly employees in archived list can be unarchived."
+            + "\nTo view all archived employees, use command 'c-archive-list'.";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX_UNARCHIVE = "The employee index provided is "
+            + "invalid."
+            + "\nThere are only %1$s employees displayed in the employee directory pane.";
     private final Index targetIndex;
 
     /**
@@ -44,7 +47,8 @@ public class UnarchiveCommand extends Command {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(String.format(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX_UNARCHIVE,
+                    model.getFilteredPersonList().size()));
         }
 
         Person personToUnarchive = lastShownList.get(targetIndex.getZeroBased());

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -28,7 +28,7 @@ public class PersonListPanel extends UiPart<Region> {
      */
     public PersonListPanel(ObservableList<Person> personList) {
         super(FXML);
-        headerPersonList.setText("Employees' contact details");
+        headerPersonList.setText("Employee Directory:");
         personListView.setItems(personList);
         personListView.setCellFactory(listView -> new PersonListViewCell());
     }

--- a/src/test/java/seedu/address/logic/commands/ArchiveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ArchiveCommandTest.java
@@ -9,7 +9,6 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.model.IngredientBook;
 import seedu.address.model.Model;
@@ -28,7 +27,9 @@ public class ArchiveCommandTest {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         ArchiveCommand archiveCommand = new ArchiveCommand(outOfBoundIndex);
 
-        assertCommandFailure(archiveCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(archiveCommand, model,
+                String.format(ArchiveCommand.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX_ARCHIVE,
+                model.getFilteredPersonList().size()));
     }
 
     @Test
@@ -42,7 +43,9 @@ public class ArchiveCommandTest {
 
         ArchiveCommand archiveCommand = new ArchiveCommand(outOfBoundIndex);
 
-        assertCommandFailure(archiveCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(archiveCommand, model,
+                String.format(ArchiveCommand.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX_ARCHIVE,
+                model.getFilteredPersonList().size()));
     }
 
     @Test


### PR DESCRIPTION
- Change "person(s)" to "employee(s)" in the feedback messages.
- Change "person list" to "employee directory".
- Only changed those for "c-archive"/"c-unarchive"/"c-archive-all"/"c-archive-list"/"c-tag-find"/"c-today"/"c-tomorrow"/"c-list" commands.
- Change "c-list" command to "c-active-list" to show a list of active(unarchived) employees.